### PR TITLE
Sale and payment details

### DIFF
--- a/models/Sale.js
+++ b/models/Sale.js
@@ -48,9 +48,9 @@ class Sale extends Entity {
         this.validateCreate({
           type,
           amount,
-          userId: id_User,
+          id_User,
           details,
-          paymentMethod: id_PaymentMethod,
+          id_PaymentMethod,
         })
       ) {
         await sequelize.sync();

--- a/models/Sale.js
+++ b/models/Sale.js
@@ -295,19 +295,24 @@ class Sale extends Entity {
     }
   }
 
-  async getEntity(number) {
+  async getEntity(number, type) {
     try {
-      User.dbModel.hasMany(dbSale);
-      PaymentMethod.dbModel.hasMany(dbSale);
-      this.dbModel.belongsTo(PaymentMethod.dbModel);
-      this.dbModel.belongsTo(User.dbModel);
+      if (isNum(number) & !!isString(type)) {
+        User.dbModel.hasMany(dbSale);
+        PaymentMethod.dbModel.hasMany(dbSale);
+        this.dbModel.belongsTo(PaymentMethod.dbModel);
+        this.dbModel.belongsTo(User.dbModel);
 
-      return await this.dbModel.findAll({
-        include: [User.dbModel, PaymentMethod.dbModel],
-        where: { number },
-      });
+        return await this.dbModel.findOne({
+          include: [User.dbModel, PaymentMethod.dbModel],
+          where: { number, type },
+        });
+      } else {
+        return false;
+      }
     } catch (e) {
       console.error(e);
+      throw e;
     }
   }
 }

--- a/models/Sale.js
+++ b/models/Sale.js
@@ -48,9 +48,9 @@ class Sale extends Entity {
         this.validateCreate({
           type,
           amount,
-          id_User,
+          userId: id_User,
           details,
-          id_PaymentMethod,
+          paymentMethod: id_PaymentMethod,
         })
       ) {
         await sequelize.sync();
@@ -285,11 +285,29 @@ class Sale extends Entity {
       PaymentMethod.dbModel.hasMany(dbSale);
       this.dbModel.belongsTo(PaymentMethod.dbModel);
       this.dbModel.belongsTo(User.dbModel);
+
       return this.dbModel.findAll({
         include: [User.dbModel, PaymentMethod.dbModel],
       });
     } catch (e) {
+      console.error(e);
       throw e;
+    }
+  }
+
+  async getEntity(number) {
+    try {
+      User.dbModel.hasMany(dbSale);
+      PaymentMethod.dbModel.hasMany(dbSale);
+      this.dbModel.belongsTo(PaymentMethod.dbModel);
+      this.dbModel.belongsTo(User.dbModel);
+
+      return await this.dbModel.findAll({
+        include: [User.dbModel, PaymentMethod.dbModel],
+        where: { number },
+      });
+    } catch (e) {
+      console.error(e);
     }
   }
 }

--- a/models/Sale.js
+++ b/models/Sale.js
@@ -2,6 +2,8 @@ const { Sequelize, sequelize } = require('./db');
 const SaleDetail = require('./SaleDetail');
 const Entity = require('./Entity');
 const Product = require('./Product');
+const User = require('./User');
+const PaymentMethod = require('./PaymentMethod');
 
 const { isString, isNum } = require('../utils/validate');
 
@@ -19,12 +21,14 @@ const dbSale = sequelize.define('sales', {
     primaryKey: true,
   },
   amount: { type: Sequelize.FLOAT },
-  id_User: {
+  userId: {
     type: Sequelize.INTEGER,
+    field: 'id_User',
     references: { model: 'users', key: 'id' },
   },
-  id_PaymentMethod: {
+  paymentMethodId: {
     type: Sequelize.INTEGER,
+    field: 'id_PaymentMethod',
     references: { model: 'paymentMethods', key: 'id' },
   },
 });
@@ -272,6 +276,20 @@ class Sale extends Entity {
       }
     } catch (e) {
       console.error(e);
+    }
+  }
+
+  getAll() {
+    try {
+      User.dbModel.hasMany(dbSale);
+      PaymentMethod.dbModel.hasMany(dbSale);
+      this.dbModel.belongsTo(PaymentMethod.dbModel);
+      this.dbModel.belongsTo(User.dbModel);
+      return this.dbModel.findAll({
+        include: [User.dbModel, PaymentMethod.dbModel],
+      });
+    } catch (e) {
+      throw e;
     }
   }
 }

--- a/routes/cashShifts.js
+++ b/routes/cashShifts.js
@@ -30,7 +30,7 @@ router.get('/last', protected, async (req, res) => {
     res.send(fewShifts);
   } catch (e) {
     console.error(e);
-    res.sendStatus(400);
+    res.sendStatus(status.INTERNAL_ERROR);
   }
 });
 

--- a/routes/cashShifts.js
+++ b/routes/cashShifts.js
@@ -24,6 +24,16 @@ router.get('/last', protected, async (req, res) => {
   }
 });
 
+router.get('/last', protected, async (req, res) => {
+  try {
+    const fewShifts = await CashShift.getClosestShift();
+    res.send(fewShifts);
+  } catch (e) {
+    console.error(e);
+    res.sendStatus(400);
+  }
+});
+
 router.post('/', protected, async (req, res) => {
   try {
     const newCashShift = await CashShift.create({ ...req.body });

--- a/routes/products.js
+++ b/routes/products.js
@@ -3,6 +3,10 @@ const router = require('express').Router();
 const { protected } = require('../middlewares');
 const Product = require('../models/Product');
 const status = require('../utils/statusCodes');
+const Sale = require('../models/Sale');
+
+const isBefore = require('date-fns/is_before');
+const { stringToDate } = require('../utils/dates');
 
 router.get('/search', protected, async (req, res) => {
   try {
@@ -49,6 +53,38 @@ router.get('/:id', protected, async (req, res) => {
   } catch (e) {
     console.error(e);
     res.sendStatus(status.INTERNAL_ERROR);
+  }
+});
+
+router.get('/:productId/sales', protected, async (req, res) => {
+  try {
+    let sales;
+    if (req.params.productId) {
+      if (!req.query.from && !req.query.to) {
+        sales = await Sale.getSaleWithProduct(req.params.productId);
+        sales ? res.send(sales) : res.send({});
+      } else if (req.query.from && req.query.to) {
+        const from = stringToDate(req.query.from);
+        const to = stringToDate(req.query.to);
+        if (isBefore(from, to)) {
+          sales = await Sale.getSaleWithProductByDates(
+            req.params.productId,
+            from,
+            to
+          );
+          sales ? res.send(sales) : res.send({});
+        } else {
+          res.status(400).send('Verify dates.');
+        }
+      } else {
+        res.status(400).send('Both dates must be included.');
+      }
+    } else {
+      res.send({});
+    }
+  } catch (e) {
+    console.error(e);
+    res.sendStatus(400);
   }
 });
 

--- a/routes/products.js
+++ b/routes/products.js
@@ -74,17 +74,17 @@ router.get('/:productId/sales', protected, async (req, res) => {
           );
           sales ? res.send(sales) : res.send({});
         } else {
-          res.status(400).send('Verify dates.');
+          res.status(status.BAD_REQUEST).send('Verify dates.');
         }
       } else {
-        res.status(400).send('Both dates must be included.');
+        res.status(status.BAD_REQUEST).send('Both dates must be included.');
       }
     } else {
       res.send({});
     }
   } catch (e) {
     console.error(e);
-    res.sendStatus(400);
+    res.sendStatus(status.INTERNAL_ERROR);
   }
 });
 

--- a/routes/sales.js
+++ b/routes/sales.js
@@ -53,13 +53,16 @@ router.post('/', protected, async (req, res) => {
   }
 });
 
-router.get('/search/:number', protected, async (req, res) => {
+router.get('/search/:number/:type', protected, async (req, res) => {
   try {
-    const sale = await Sale.getEntity(req.params.number);
-    res.send(sale);
+    const sale = await Sale.getEntity(req.params.number, req.params.type);
+    console.log(sale)
+    sale
+      ? res.send(sale)
+      : res.status(status.BAD_REQUEST).send('Validate data format.');
   } catch (e) {
     console.error(e);
-    res.sendStatus(status.BAD_REQUEST);
+    res.sendStatus(status.INTERNAL_ERROR);
   }
 });
 

--- a/routes/sales.js
+++ b/routes/sales.js
@@ -7,38 +7,6 @@ const isBefore = require('date-fns/is_before');
 const { stringToDate } = require('../utils/dates');
 const status = require('../utils/statusCodes');
 
-router.get('/products/:productId', protected, async (req, res) => {
-  try {
-    let sales;
-    if (req.params.productId) {
-      if (!req.query.from && !req.query.to) {
-        sales = await Sale.getSaleWithProduct(req.params.productId);
-        sales ? res.send(sales) : res.send({});
-      } else if (req.query.from && req.query.to) {
-        const from = stringToDate(req.query.from);
-        const to = stringToDate(req.query.to);
-        if (isBefore(from, to)) {
-          sales = await Sale.getSaleWithProductByDates(
-            req.params.productId,
-            from,
-            to
-          );
-          sales ? res.send(sales) : res.send({});
-        } else {
-          res.status(400).send('Verify dates.');
-        }
-      } else {
-        res.status(400).send('Both dates must be included.');
-      }
-    } else {
-      res.send({});
-    }
-  } catch (e) {
-    console.error(e);
-    res.sendStatus(400);
-  }
-});
-
 router.get('/', protected, async (req, res) => {
   try {
     let sales;


### PR DESCRIPTION
overwrite getEntity for sales, bcause now get all the sales with number as a parameter. Before it only brought me one sale. 
And separate the endpoint to get sales by ranges, and get sales with product by range